### PR TITLE
Fixing Dockerfile (undoing damage introduced in 7f04e1b)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ RUN apt-get update && apt-get install -y \
     dbus-x11 \
     terminator && \
     rm -rf /var/lib/apt/lists/*
-C
+
 # CS427 Additions: Navigation stack + Turtlebot3 simulation packages
-RUN apt-get update && sudo apt-get install -y \
+RUN apt-get update && apt-get install -y \
 	ros-${ROS_DISTRO}-turtlebot3-slam \
 	ros-${ROS_DISTRO}-slam-gmapping \
 	ros-${ROS_DISTRO}-turtlebot3-gazebo \


### PR DESCRIPTION
There was an extra 'C' introduced by the 7f04e1b, that broke the Dockerfile. Also, there is no need to run "sudo apt-get install" in the second RUN invocation